### PR TITLE
fixing singularity issue

### DIFF
--- a/src/GLM_fit_dev.py
+++ b/src/GLM_fit_dev.py
@@ -5,6 +5,7 @@ import visual_behavior_glm.src.GLM_params as glm_params
 plt.ion()
 
 # VERSION = 4
+# glm_params.make_run_json(1,label='testing',username=alex, src_path = '', TESTING=True)
 # run_params = glm_params.load_run_json(VERSION)
 # import_dir = self.run_params['model_freeze_dir'].rstrip('/')
 # module_name = 'GLM_fit_tools'
@@ -33,6 +34,7 @@ if False:
     session, fit, design = gft.fit_experiment(oeid, run_params)
     drop_results = gft.build_dataframe_from_dropouts(fit)
     L2_results = gft.L2_report(fit)
+
 
 def demonstration():
     # Make demonstration of design kernel, and model structure

--- a/src/GLM_fit_tools.py
+++ b/src/GLM_fit_tools.py
@@ -123,9 +123,9 @@ def evaluate_ridge(fit, design,run_params):
     else:
         print('Evaluating a grid of regularization values')
         if run_params['L2_grid_type'] == 'log':
-            fit['L2_grid'] = np.concatenate([[0],np.geomspace(run_params['L2_grid_range'][0], run_params['L2_grid_range'][1],num = run_params['L2_grid_num'])])
+            fit['L2_grid'] = np.geomspace(run_params['L2_grid_range'][0], run_params['L2_grid_range'][1],num = run_params['L2_grid_num'])
         else:
-            fit['L2_grid'] = np.concatenate([[0],np.linspace(run_params['L2_grid_range'][0], run_params['L2_grid_range'][1],num = run_params['L2_grid_num'])])
+            fit['L2_grid'] = np.linspace(run_params['L2_grid_range'][0], run_params['L2_grid_range'][1],num = run_params['L2_grid_num'])
         train_cv = np.empty((fit['dff_trace_arr'].shape[1], len(fit['L2_grid']))) 
         test_cv  = np.empty((fit['dff_trace_arr'].shape[1], len(fit['L2_grid']))) 
         X = design.get_X()

--- a/src/GLM_params.py
+++ b/src/GLM_params.py
@@ -169,12 +169,15 @@ def make_run_json(VERSION,label='',username=None, src_path=None, TESTING=False):
         raise Exception('L2_use_fixed_value is True, but have None for L2_fixed_lambda')
     if (not run_params['L2_use_fixed_value']) and (run_params['L2_fixed_lambda'] is not None):
         raise Exception('L2_use_fixed_value is False, but L2_fixed_lambda has been set')      
+    if run_params['L2_use_fixed_value']:
+        assert run_params['L2_fixed_lambda'] > 0, "Must have some positive regularization value to prevent singular matrix"
 
     # Check L2 Optimization parameters
     if (a or b):
         assert run_params['L2_grid_num'] > 0, "Must have at least one grid option for L2 optimization"
         assert len(run_params['L2_grid_range']) ==2, "Must have a minimum and maximum L2 grid option"
         assert run_params['L2_grid_type'] in ['log','linear'], "L2_grid_type must be log or linear"
+        assert run_params['L2_grid_range'][0] > 0, "Must have a positive regularization minimum value."
 
     with open(json_path, 'w') as json_file:
         json.dump(run_params, json_file, indent=4)


### PR DESCRIPTION
@dougollerenshaw noticed a large number of jobs crashing because of a singular matrix issue. 

After going through the log files I noticed several things. 
1. The crashes always happened in the `evaluating_ridge` function on the first value which was forced to be `lambda=0`. I verified this on two example sessions. 
2. The crashes were dependent on the cross validation splits. I found two sessions and verified that by repeatedly re-sampling the splits I could make the issue happen or not happen. 

So that leads to a quick solution, which is remove the lambda=0 case, and enforce that either `L2_fixed_lambda > 0` or `L2_grid_range[0] > 0`. This PR enforces these parameter settings when making the run json, and removes the lambda=0 case in evaluate_ridge.

I believe the issue was that for some cv_splits, by chance we sample a region of the session where for some regressor, there are no events happening. That means the parameters for that kernel project into the nullspace of the design matrix, so the solution of the linear system is singular, any value of those parameters is a valid solution, and we cant invert the matrix to find the best solution. By adding some positive regularization value we effectively stabilize the linear system by favoring the parameter = 0 solution, breaking any singularity. I can't guarantee this issue wont happen again, but I think it will probably be very rare.