### PR TITLE
reconfigure use_previous_fit flag

### DIFF
--- a/scripts/fit_glm.py
+++ b/scripts/fit_glm.py
@@ -18,10 +18,17 @@ parser.add_argument(
     metavar='glm version',
     help='model version to use'
 )
+parser.add_argument(
+    '--use-previous-fit', 
+    action='store_true',
+    default=False,
+    dest='use_previous_fit', 
+    help='use previous fit if it exists (boolean, default = False)'
+)
 
-def fit_experiment(oeid, version, log_results=True, log_weights=True):
-    glm = GLM(oeid, version, log_results, log_weights)
+def fit_experiment(oeid, version, log_results=True, log_weights=True, use_previous_fit=False):
+    glm = GLM(oeid, version, log_results=log_results, log_weights=log_weights, use_previous_fit=use_previous_fit)
 
 if __name__ == '__main__':
     args = parser.parse_args()
-    fit_experiment(args.oeid, args.version)
+    fit_experiment(args.oeid, args.version, use_previous_fit=args.use_previous_fit)

--- a/src/glm.py
+++ b/src/glm.py
@@ -28,7 +28,7 @@ class GLM(object):
         inputs (List): if use_inputs, this must be a list of session, fit, and design objects
     '''
 
-    def __init__(self, ophys_experiment_id, version, log_results=True, log_weights=True,use_previous_fit=False, recompute=False, use_inputs=False, inputs=None):
+    def __init__(self, ophys_experiment_id, version, log_results=True, log_weights=True,use_previous_fit=False, recompute=True, use_inputs=False, inputs=None):
         
         self.version = version
         self.ophys_experiment_id = ophys_experiment_id
@@ -48,8 +48,11 @@ class GLM(object):
         elif use_previous_fit:
             # Attempts to load existing results
             try:
-                self.load_fit_model()       
+                print('loading previous fit...')
+                self.load_fit_model()  
+                print('done loading previous fit')     
             except:
+                print('failed to load previous fit, reload flag is set to {}'.format(reload))
                 if recompute:
                     # Just computes the model, since it crashed on load
                     self.fit_model()


### PR DESCRIPTION
makes 'recompute' flag True by default.
allows '--use-previous-version' flag to be passed in `fit_glm.py`