### PR TITLE
Add ROI IDs to results and dropout_summary

### DIFF
--- a/visual_behavior_glm/glm.py
+++ b/visual_behavior_glm/glm.py
@@ -123,6 +123,19 @@ class GLM(object):
         # self.dropout_summary = pd.merge(dropout_summary, adj_dropout_summary,on=['dropout', 'cell_specimen_id']).reset_index()
         # self.dropout_summary.columns.name = None
         self.dropout_summary = gat.generate_results_summary(self)
+
+        # add roi_ids
+        self.dropout_summary = self.dropout_summary.merge(
+            self.session.cell_specimen_table[['cell_roi_id']],
+            left_on='cell_specimen_id',
+            right_index=True
+        )
+
+        self.results = self.results.merge(
+            self.session.cell_specimen_table[['cell_roi_id']],
+            left_index=True,
+            right_index=True,
+        )
  
     def get_cells_above_threshold(self, threshold=0.01):
         '''


### PR DESCRIPTION
adding ROI IDs to results and dropout_summary dataframes in GLM class. This will ensure that roi_id is stored in mongo.