### PR TITLE
add cell ROI plot across sessions

### DIFF
--- a/visual_behavior_glm/GLM_visualization_tools.py
+++ b/visual_behavior_glm/GLM_visualization_tools.py
@@ -14,6 +14,7 @@ import time
 from tqdm import tqdm
 from matplotlib import animation, rc
 import matplotlib.pyplot as plt
+import matplotlib.patches as patches
 import gc
 from scipy import ndimage
 from scipy import stats


### PR DESCRIPTION
This PR adds a function to visualize a single cell across all sessions with a valid GLM fit (for a given GLM version).

Example use:
```
import visual_behavior_glm.GLM_visualization_tools as gvt

cell_specimen_id = 817101743
glm_version = '10a_L2_optimize_by_session'

fig,ax = gvt.view_cell_across_sessions(cell_specimen_id, glm_version)
```
which returns:
![image](https://user-images.githubusercontent.com/19944442/100932743-2defc780-34a1-11eb-9bfb-928c82bc88c8.png)

The function assumes that a cell has 6 sessions associated with it. Missing sessions are filled with a string stating 'no model fit'. Eg:

```
cell_specimen_id = 1007039174
glm_version = '10a_L2_optimize_by_session'

fig,ax = gvt.view_cell_across_sessions(cell_specimen_id, glm_version)
```
![image](https://user-images.githubusercontent.com/19944442/100932886-67c0ce00-34a1-11eb-99ce-660dc5ea3084.png)
