### PR TITLE
deal with new timestamp column in session.eye_tracking

### DIFF
--- a/visual_behavior_glm/GLM_fit_tools.py
+++ b/visual_behavior_glm/GLM_fit_tools.py
@@ -763,8 +763,8 @@ def process_eye_data(session,run_params,ophys_timestamps=None):
     ophys_eye = pd.DataFrame({'timestamps':ophys_timestamps})
     z_score = ['eye_width','pupil_radius']
     for column in eye.keys():
-        if column != 'time':
-            f = scipy.interpolate.interp1d(eye['time'], eye[column], bounds_error=False)
+        if column != 'timestamps':
+            f = scipy.interpolate.interp1d(eye['timestamps'], eye[column], bounds_error=False)
             ophys_eye[column] = f(ophys_eye['timestamps'])
             ophys_eye[column].fillna(method='ffill',inplace=True)
             if column in z_score:


### PR DESCRIPTION
There has been a change in the naming convention of the timestamp column in session.eye_tracking. The timestamp column name was changed from 'time' to 'timestamps'. I'm unclear on whether this change occurred in the new SDK version, or if it came from a change when merging in the VBA dev branch. This PR adjusts the GLM_fit_tools.process_eye_data() method to use the new column name.