### PR TITLE
GLM class and visualization updates for SDK 2.8.0

### DIFF
--- a/visual_behavior_glm/GLM_visualization_tools.py
+++ b/visual_behavior_glm/GLM_visualization_tools.py
@@ -567,10 +567,10 @@ def plot_rewards(session, ax, y_loc=0, t_span=None):
 
 def plot_running(session, ax, t_span=None):
     if t_span:
-        running_df = session.running_data_df.reset_index().query(
+        running_df = session.running_speed.reset_index().query(
             'timestamps >= {} and timestamps <= {}'.format(t_span[0], t_span[1]))
     else:
-        running_df = session.running_data_df.reset_index()
+        running_df = session.running_speed.reset_index()
     ax.plot(
         running_df['timestamps'],
         running_df['speed'],
@@ -578,8 +578,8 @@ def plot_running(session, ax, t_span=None):
         linewidth=3
     )
     ax.set_ylim(
-        session.running_data_df['speed'].min(),
-        session.running_data_df['speed'].max(),
+        session.running_speed['speed'].min(),
+        session.running_speed['speed'].max(),
     )
 
 def plot_pupil(session, ax, t_span=None):
@@ -672,7 +672,7 @@ def build_simulated_FOV(session, F_dataframe, column):
 
         F_cell = F_dataframe.loc[cell_specimen_id][column]
         # arr += session.cell_specimen_table.loc[cell_specimen_id]['image_mask']*F_cell
-        arr += session.get_roi_masks().loc[{'cell_specimen_id':cell_specimen_id}].values*F_cell
+        arr += session.cell_specimen_table.loc[cell_specimen_id]['roi_mask']*F_cell
 
     return arr
 
@@ -1068,12 +1068,12 @@ class GLM_Movie(object):
             )['cell_roi_id'][0]
             if cell_specimen_id in glm.session.cell_specimen_table.index.tolist():
                 print('FOUND CELL SPECIMEN ID')
-                self.com = ndimage.measurements.center_of_mass(glm.session.get_roi_masks().loc[{'cell_specimen_id':cell_specimen_id}].values)
+                self.com = ndimage.measurements.center_of_mass(glm.session.cell_specimen_table.loc[cell_specimen_id]['roi_mask'])
             elif cell_roi_id in glm.session.cell_specimen_table['cell_roi_id'].tolist():
                 print('FOUND CELL ROI ID')
                 correct_csid= self.glm.session.cell_specimen_table.query('cell_roi_id == @cell_roi_id').index[0]
                 # self.com = ndimage.measurements.center_of_mass(glm.session.cell_specimen_table.query('cell_roi_id == @cell_roi_id')['roi_mask'].values[0])
-                self.com = ndimage.measurements.center_of_mass(glm.session.get_roi_masks().loc[{'cell_specimen_id':correct_csid}].values)
+                self.com = ndimage.measurements.center_of_mass(glm.session.cell_specimen_table.loc[cell_specimen_id]['roi_mask'])
                 print(self.com)
             else:
                 print('COULD NOT FIND CELL')
@@ -1185,8 +1185,8 @@ class GLM_Movie(object):
         plot_running(glm.session, ax['running'], t_span=t_span)
         # set running y lims
         ax['running'].set_ylim(
-            self.glm.session.running_data_df.query(query_string)['speed'].min() - 5,
-            self.glm.session.running_data_df.query(query_string)['speed'].max() + 5
+            self.glm.session.running_speed.query(query_string)['speed'].min() - 5,
+            self.glm.session.running_speed.query(query_string)['speed'].max() + 5
         )
         plot_pupil(glm.session, ax['pupil'], t_span=t_span)
         # set pupil ylims

--- a/visual_behavior_glm/glm.py
+++ b/visual_behavior_glm/glm.py
@@ -1,5 +1,6 @@
 import warnings
 import visual_behavior_glm.GLM_analysis_tools as gat
+import visual_behavior_glm.GLM_fit_tools as gft
 import visual_behavior_glm.GLM_visualization_tools as gvt
 import visual_behavior_glm.GLM_params as glm_params
 import sys
@@ -197,7 +198,12 @@ class GLM(object):
         # build a dataframe with columns for 'fit_array', 'dff_trace_arr', 'events_trace_arr'
         fit_df = self.fit['fit_trace_arr'].to_dataframe(name='fit_array')
         dff_df = self.fit['dff_trace_arr'].to_dataframe(name='dff')
-        event_df = self.fit['events_trace_arr'].to_dataframe(name='events')
+        try:
+            event_df = self.fit['events_trace_arr'].to_dataframe(name='events')
+        except AttributeError:
+            timestamps_to_use = gft.get_ophys_frames_to_use(self.session)
+            events_trace_arr = gft.get_events_arr(self.session, timestamps_to_use) 
+            event_df = events_trace_arr.to_dataframe(name='events')
         df = fit_df.reset_index().merge(
             dff_df.reset_index(),
             left_on=['fit_trace_timestamps','cell_specimen_id'],


### PR DESCRIPTION
Some more naming updates to be consistent with SDK 2.8.0

Also, dealing with the fact that events aren't being saved to the cached fit when we fit dff. I'm just extracting them from the session object again.