### PR TITLE
Solution for issue #286 - split by engagement when loading a pre-fit model

### DIFF
--- a/visual_behavior_glm/GLM_fit_tools.py
+++ b/visual_behavior_glm/GLM_fit_tools.py
@@ -36,6 +36,8 @@ def load_fit_experiment(ophys_experiment_id, run_params):
     session = load_data(ophys_experiment_id)
     design = DesignMatrix(fit)
     design = add_kernels(design, run_params, session,fit)
+    # split by engagement
+    design,fit = split_by_engagement(design, run_params, session, fit)
     return session, fit, design
 
 def check_run_fits(VERSION):


### PR DESCRIPTION
Solves issue #286 by implementing @alexpiet's suggested fix. 

```python
design,fit = split_by_engagement(design, run_params, session, fit)
```
is now called within `GLM_fit_tools.load_fit_experiment`