### PR TITLE
Fixing path issue got gat.get_versions()

### DIFF
--- a/visual_behavior_glm/GLM_params.py
+++ b/visual_behavior_glm/GLM_params.py
@@ -7,9 +7,9 @@ import shutil
 
 import visual_behavior.data_access.loading as loading
 
-OUTPUT_DIR_BASE = '/allen/programs/braintv/workgroups/nc-ophys/visual_behavior/ophys_glm'
+OUTPUT_DIR_BASE = r'//allen/programs/braintv/workgroups/nc-ophys/visual_behavior/ophys_glm'
 
-def get_versions(vrange=[10,20]):
+def get_versions(vrange=[15,20]):
     versions = os.listdir(OUTPUT_DIR_BASE)
     out_versions = []
     for dex, val in enumerate(np.arange(vrange[0],vrange[1])):


### PR DESCRIPTION
- [x] adds `r//` to the path for the versions. I have no idea how this works, but it seems to work in VBA. I can't test it on windows because I dont have access to a windows machine. 

Before approving, can you test it?