### PR TITLE
Fix refit

### DIFF
--- a/visual_behavior_glm/GLM_fit_tools.py
+++ b/visual_behavior_glm/GLM_fit_tools.py
@@ -808,11 +808,11 @@ def build_dataframe_from_dropouts(fit,run_params):
 
     if 'var_shuffle_cells' in fit:
         # If the shuffle across cells was computed, record average VE for each cell
-        results['shuffle_cells'] = np.nanmean(fit['var_shuffle_cells'],1) 
+        results['Full__shuffle_cells'] = np.nanmean(fit['var_shuffle_cells'],1) 
 
     if 'var_shuffle_time' in fit:
         # If the shuffle across time was computed, record average VE for each cell
-        results['shuffle_time'] = np.nanmean(fit['var_shuffle_time'],1) 
+        results['Full__shuffle_time'] = np.nanmean(fit['var_shuffle_time'],1) 
 
     return results
 


### PR DESCRIPTION
- When I logged the shuffle results, it created a bug in how the results dataframe is built before logging to mongo.
- The fix was simple enough to put the shuffle results in the same format as the other results being logged. 