### PR TITLE
Cluster statistics updates

### DIFF
--- a/visual_behavior_glm/GLM_clustering.py
+++ b/visual_behavior_glm/GLM_clustering.py
@@ -308,7 +308,8 @@ def add_hochberg_correction(table):
     table = table.sort_values(by='pvalue').reset_index()
     
     # compute the corrected pvalue based on the rank of each test
-    table['imq'] = table.index.values/len(table)*0.05
+    # Need to use rank starting at 1
+    table['imq'] = (1+table.index.values)/len(table)*0.05
 
     # Find the largest pvalue less than its corrected pvalue
     # all tests above that are significant


### PR DESCRIPTION
- [x] @yavorska-iryna found a bug in how I was computing the chi-squared tests. In later versions of scipy it throws an error if the sum of `f` and `f_expected` differ. However I was running an old version of scipy, so I missed this. The problem resulted in how I was computing the null hypothesis values of `f_expected`. I was computing them using the average proportion calculated by averaging the sample proportion from the 4 locations (averaging 4 proportions). However, I should have been computing the average proportion by first assuming the null hypothesis is true and then you simple calculate the proportion by number of cells in each cluster divided by total number of cells. This code implements a fix to resolve the issue.
- [x] After dealing with this issue, I was surprised to see that none of the VIP clusters were significant. Looking at the p values from the statistics table, one of the clusters had `p=0.0015` but then it didn't survive multiple comparisons. This seemed very wrong, so I investigated. Turns out the problem was the `imq` values used by the benjamini hochsburg correction uses the rank of each ttest starting at 1, and I was computing it using rank starting at 0. Fixing it the one VIP cluster is significant. The effect of this bug was that if only one cluster was significant, it would never pass multiple comparisons corrections. If multiple clusters were significant, the multiple comparisons corrections would be slightly too conservative. 