### PR TITLE
Updating GLM_cluster to be agnostic to location

### DIFF
--- a/visual_behavior_glm/GLM_clustering.py
+++ b/visual_behavior_glm/GLM_clustering.py
@@ -136,6 +136,11 @@ def plot_proportion_cre(df,areas, fig,ax, cre):
     ax.axvline(-0.5,color='k',linewidth=.5)
 
 def plot_proportion_differences(df,areas=None):
+    '''
+        Computes, then plots, the proportion of cells in each location within each cluster
+        relative to a 1/n average distribution across n clusters. 
+    '''
+
     if areas is None:
         # Get areas
         areas = np.sort(df['location'].unique())    
@@ -151,6 +156,9 @@ def plot_proportion_differences(df,areas=None):
     plt.savefig(filedir+'cluster_proportion_differences.png')
 
 def compute_proportion_differences_cre(df, cre,areas):
+    '''
+        compute proportion differences relative to 1/n average
+    '''
     # count cells in each area/cluster
     table = df.query('cre_line == @cre').groupby(['cluster_id','location'])['cell_specimen_id'].count().unstack()
     table = table[areas]


### PR DESCRIPTION
- Previously things were hard coded to use depth/area. 
- Now things operation on the 'location' column resolves #425 
- If you pass in a list of strings to the `areas` optional argument that you can control the order the locations are plotted. If you do not pass one in, then the unique values in the location column will be used in alphabetical order. 
   - Important: If the input argument `areas` does not contain exactly the unique values in `location` an assertion error will be raised. 

## Making Plots
To make things work like before on depth/area combinations
```
import visual_behavior_glm.GLM_clustering as gc
df = gc.load_cluster_labels()
areas =['VISp_upper','VISp_lower','VISl_upper','VISl_lower']]
gc.plot_proportions(df,areas)
```

If you just want to look at the cortical area
```
df_just_area = df.copy()
df_just_area['location'] = df_just_area['targeted_structure']
just_areas = ['VISp','VISl']
gc.plot_proportions(df_just_areas,just_areas)
```

If you just want to look at cortical depth
```
df_just_depth = df.copy()
df_just_depth['location'] = df_just_depth['coarse_binned_depth']
just_depth =['lower','upper']
gc.plot_proportions(df_just_depth, just_depth)
```

Note that `just_depth` is already in sorted order, so you can simply call `gc.plot_proportions(df_just_depth)` to get the same plot

## Computing statistics for use elsewhere
To make things work like before
```
proportions, stats = gc.final(df,'Sst-IRES-Cre',areas)
```

If you just want to look at cortical area
```
proportions, stats = gc.final(df_just_areas,'Sst-IRES-Cre',just_areas)
```

If you just want to look at cortical depth
```
proportions, stats = gc.final(df_just_depth,'Sst-IRES-Cre',just_depth)
```

## Example output
![Screen Shot 2022-05-10 at 7 42 17 PM](https://user-images.githubusercontent.com/7605170/167758260-b4cd93ef-e41a-4e9c-be18-2723a383f315.png)
