### PR TITLE
checking stats for figure 3D across cell types

### DIFF
--- a/visual_behavior_glm/GLM_visualization_tools.py
+++ b/visual_behavior_glm/GLM_visualization_tools.py
@@ -4257,6 +4257,28 @@ def plot_population_averages(results_pivoted, run_params, dropouts_to_show = ['a
 
     return summary_data
 
+def test_significant_across_cell(data, feature):
+
+    data = data[~data[feature].isnull()].copy()
+    anova = stats.f_oneway(
+        data.query('cre_line == "Slc17a7-IRES2-Cre"')[feature],  
+        data.query('cre_line == "Sst-IRES-Cre"')[feature],  
+        data.query('cre_line == "Vip-IRES-Cre"')[feature]
+        )
+    comp = mc.MultiComparison(data[feature], data['cre_line'])
+    post_hoc_res = comp.tukeyhsd()
+    tukey_table = pd.read_html(post_hoc_res.summary().as_html(),header=0, index_col=0)[0]
+    tukey_table = tukey_table.reset_index()
+    mapper = {
+        'Slc17a7-IRES2-Cre':0,
+        'Sst-IRES-Cre':1,
+        'Vip-IRES-Cre':2,
+        }
+    tukey_table['x1'] = [mapper[str(x)] for x in tukey_table['group1']]
+    tukey_table['x2'] = [mapper[str(x)] for x in tukey_table['group2']]
+    return anova, tukey_table
+
+
 
 def test_significant_dropout_averages(data,feature):
     data = data[~data[feature].isnull()].copy()

--- a/visual_behavior_glm/platform_paper_figure_script.py
+++ b/visual_behavior_glm/platform_paper_figure_script.py
@@ -70,6 +70,11 @@ gvt.plot_kernel_comparison_by_experience(weights_df, run_params, 'omissions')
 # Returns a dataframe with rows for cre/dropout, and columns describing
 # the dropout score
 stats_D = gvt.plot_dropout_summary_population(results,run_params) 
+results_pivoted_active = results_pivoted.query('not passive').copy()
+anova, tukey = gvt.test_significant_across_cell(results_pivoted_active,'all-images')
+anova, tukey = gvt.test_significant_across_cell(results_pivoted_active,'omissions')
+anova, tukey = gvt.test_significant_across_cell(results_pivoted_active,'behavioral')
+anova, tukey = gvt.test_significant_across_cell(results_pivoted_active,'task')
 
 ## Panel E - Dropout averages for experience and cre-line
 '''


### PR DESCRIPTION
- adds notes to `platform_paper_figure_script`
- Adds a function to `gvt.test_significant_across_cells()` to do ANOVA + tukey MC to compare the figure 3D average coding scores across cell types. 